### PR TITLE
ci: build and package only xdp-trafficgen

### DIFF
--- a/.github/workflows/covscan.yml
+++ b/.github/workflows/covscan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare packages
         run: |
           sudo apt-get update
-          sudo apt-get install zstd binutils-dev elfutils libpcap-dev libelf-dev gcc-multilib pkg-config wireshark tshark bpfcc-tools python3 python3-pip python3-setuptools qemu-kvm rpm2cpio libdw-dev libdwarf-dev
+          sudo apt-get install libpcap-dev libelf-dev gcc-multilib pkg-config bpftool
 
       - name: Prepare Clang
         run: |
@@ -43,7 +43,7 @@ jobs:
       - name: Build with cov-build
         run: |
           export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
-          cov-build --dir cov-int make
+          cov-build --dir cov-int make lib xdp-trafficgen
 
       - name: Submit the result to Coverity Scan
         run: |

--- a/.github/workflows/selftests.yml
+++ b/.github/workflows/selftests.yml
@@ -7,61 +7,36 @@ on:
     branches: [ main ]
 
 jobs:
-  selftest:
+  build-and-test:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        KERNEL_VERSION:
-          - "6.14.7-200.fc41"
-          - "6.13.7-200.fc41"
-          - "6.12.8-200.fc41"
-          - "6.10.12-200.fc40"
-          - "6.6.14-200.fc39"
-          - "6.1.9-200.fc37"
-          - "5.16.8-200.fc35"
-          - "5.11.0-156.fc34"
-          - "5.6.19-300.fc32"
-        LLVM_VERSION:
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-      fail-fast: false
-
     env:
-      KERNEL_VERSION: ${{ matrix.KERNEL_VERSION }}
-      LLVM_VERSION: ${{ matrix.LLVM_VERSION }}
-      CLANG: clang-${{ matrix.LLVM_VERSION }}
-      LLVM_STRIP: llvm-strip-${{ matrix.LLVM_VERSION }}
-      # can't use unshare on old kernels
-      DID_UNSHARE: ${{ (startsWith(matrix.KERNEL_VERSION, '5.6') || startsWith(matrix.KERNEL_VERSION, '5.11')) && 1 || 0 }}
+      LLVM_VERSION: 19
+      CLANG: clang-19
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
       - name: Prepare packages
         run: |
           sudo apt-get update
-          sudo apt-get install zstd binutils-dev elfutils libpcap-dev libelf-dev gcc-multilib pkg-config wireshark tshark bpfcc-tools python3 python3-pip python3-setuptools qemu-kvm rpm2cpio libdw-dev libdwarf-dev libcap-ng-dev socat
+          sudo apt-get install libpcap-dev libelf-dev gcc-multilib pkg-config bpftool
+
       - name: Prepare Clang
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$LLVM_VERSION main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get -qq update
           sudo apt-get -qq -y install clang-$LLVM_VERSION lld-$LLVM_VERSION llvm-$LLVM_VERSION
-      - name: Install latest bpftool
-        run: |
-          git clone --depth=1 --recurse-submodules https://github.com/libbpf/bpftool bpftool
-          make -C bpftool/src
-          sudo make install -C bpftool/src prefix=/usr
-      - name: Compile
-        run: make
-      - name: Prepare test tools
-        run: .github/scripts/prepare_test_tools.sh
-      - name: Prepare test kernel
-        run: .github/scripts/prepare_test_kernel.sh
+
+      - name: Configure
+        run: ./configure
+
+      - name: Build
+        run: make lib xdp-trafficgen
+
       - name: Run tests
-        run: .github/scripts/run_tests_in_vm.sh
+        run: make -C xdp-trafficgen test
+

--- a/packaging/rpm/xdp-tools.spec
+++ b/packaging/rpm/xdp-tools.spec
@@ -1,7 +1,7 @@
 Name:             xdp-tools
 Version:          1.5.5
 Release:          1%{?dist}
-Summary:          Utilities and example programs for use with XDP
+Summary:          XDP traffic generator and helper library
 %global _soversion 1.5.0
 
 License:          GPL-2.0-only
@@ -18,9 +18,6 @@ BuildRequires:    llvm >= 10.0.0
 BuildRequires:    make
 BuildRequires:    gcc
 BuildRequires:    pkgconfig
-BuildRequires:    m4
-BuildRequires:    emacs-nox
-BuildRequires:    wireshark-cli
 BuildRequires:    bpftool
 
 ExcludeArch:      i386 i686
@@ -34,7 +31,7 @@ Requires:         libxdp = %{version}-%{release}
 %global _hardened_build 1
 
 %description
-Utilities and example programs for use with XDP
+XDP traffic generator and libxdp helper library
 
 %package -n libxdp
 Summary:          XDP helper library
@@ -77,7 +74,7 @@ export DYNAMIC_LIBXDP=1
 export FORCE_SYSTEM_LIBBPF=1
 export FORCE_EMACS=1
 ./configure
-make %{?_smp_mflags} V=1
+make lib xdp-trafficgen %{?_smp_mflags} V=1
 
 %install
 export DESTDIR='%{buildroot}'
@@ -87,12 +84,12 @@ export RUNDIR='%{_rundir}'
 export MANDIR='%{_mandir}'
 export DATADIR='%{_datadir}'
 export HDRDIR='%{_includedir}/xdp'
-make install V=1
+make libxdp_install V=1
+make -C xdp-trafficgen install V=1
 
 %files
 %{_sbindir}/xdp-trafficgen
 %{_mandir}/man8/*
-%{_datadir}/xdp-tools/
 %license LICENSES/*
 
 %files -n libxdp


### PR DESCRIPTION
## Summary
- focus CI workflows on building and testing xdp-trafficgen
- trim RPM spec to install only xdp-trafficgen and libxdp components

## Testing
- `./configure` *(fails: Cannot find tool clang)*
- `make lib xdp-trafficgen` *(fails: No such file or directory: config.mk)*
- `make -C xdp-trafficgen test` *(fails: No such file or directory: config.mk)*


------
https://chatgpt.com/codex/tasks/task_e_6893bc7400b08321b22c1b2bed7ba923