### PR TITLE
lib: drop util from default build

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -4,7 +4,7 @@ LIBBPF_CFLAGS:=$(if $(CFLAGS),$(CFLAGS),-g -O2 -Werror -Wall) -fPIC
 LIB_DIR = .
 include defines.mk
 
-SUBDIRS=util testing
+SUBDIRS=testing
 .PHONY: $(SUBDIRS)
 
 all: $(SUBDIRS) libxdp
@@ -12,7 +12,7 @@ all: $(SUBDIRS) libxdp
 util: libxdp
 	@echo; echo "  $@"; $(MAKE) -C $@
 
-testing: libxdp util
+testing: libxdp
 	@echo; echo "  $@"; $(MAKE) -C $@
 
 .PHONY: libxdp


### PR DESCRIPTION
## Summary
- stop building util subdir by default in lib makefile
- simplify testing dependencies to only use libxdp

## Testing
- `make clean all` *(fails: fatal error bpf/libbpf.h: No such file or directory)*
- `rg util /tmp/makelog`

------
https://chatgpt.com/codex/tasks/task_e_68945e589018832195b768613a428f48