### PR TITLE
refactor: use util-prefixed headers

### DIFF
--- a/xdp-trafficgen/Makefile
+++ b/xdp-trafficgen/Makefile
@@ -16,6 +16,9 @@ EXTRA_DEPS := xdp-trafficgen.h
 USER_LIBS     = -lpthread
 TEST_FILE := tests/test-xdp-trafficgen.sh
 
+LIB_DIR ?= ../lib
+CFLAGS += -I$(LIB_DIR)
+
 include ../lib/common.mk
 
 $(USER_OBJS): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_SKEL_H)

--- a/xdp-trafficgen/xdp-trafficgen.c
+++ b/xdp-trafficgen/xdp-trafficgen.c
@@ -33,10 +33,10 @@
 #include <linux/tcp.h>
 #include <linux/netdev.h>
 
-#include "params.h"
-#include "logging.h"
-#include "util.h"
-#include "xdp_sample.h"
+#include "util/params.h"
+#include "util/logging.h"
+#include "util/util.h"
+#include "util/xdp_sample.h"
 #include "xdp-trafficgen.h"
 
 #include "xdp_trafficgen.skel.h"


### PR DESCRIPTION
## Summary
- include util headers via explicit `util/` prefix in xdp-trafficgen
- add util directory to compiler include path

## Testing
- `./configure` *(fails: Cannot find tool clang)*
- `make -C xdp-trafficgen` *(fails: config.mk: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894658027a4832193ee899c6288ddf7