### PR TITLE
chore: remove leading blank line in top Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 # SPDX-License-Identifier: GPL-2.0
 # Top level Makefile for xdp-tools
 


### PR DESCRIPTION
## Summary
- start the root Makefile with the SPDX license identifier

## Testing
- `make clean all` *(fails: bpf/libbpf.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68948dd12eec8321ad7745515d97325b