### PR TITLE
make: hint to run configure when config missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,14 @@ MAKEFLAGS += --no-print-directory
 endif
 
 include version.mk
+
+ifneq ($(wildcard config.mk),)
 include config.mk
+else
+ifeq (,$(filter config.mk,$(MAKECMDGOALS)))
+$(error config.mk is missing. Please run ./configure and ensure required prerequisites are installed)
+endif
+endif
 
 UTILS := xdp-trafficgen
 


### PR DESCRIPTION
## Summary
- stop the build early when `config.mk` is missing
- tell users to run `./configure` and install prerequisites

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68948fec10648321855f5729611ccc2a