### PR TITLE
Simplify submodule sync check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,14 @@ config.mk: configure
 	sh configure
 
 check_submodule:
-	@if [ -d .git ] && `git submodule status lib/libbpf | grep -q '^+'`; then \
-		echo "" ;\
-		echo "** WARNING **: git submodule SHA-1 out-of-sync" ;\
-		echo " consider running: git submodule update"  ;\
-		echo "" ;\
-	fi\
+	@if [ -d .git ]; then \
+		if git submodule status lib/libbpf | grep -q '^+'; then \
+			echo ""; \
+			echo "** WARNING **: git submodule SHA-1 out-of-sync"; \
+			echo " consider running: git submodule update"; \
+			echo ""; \
+		fi; \
+	fi
 
 clobber:
 	touch config.mk


### PR DESCRIPTION
## Summary
- replace backticks in `check_submodule` with nested `if` checks for clarity

## Testing
- `make check_submodule` *(fails: config.mk is missing)*
- `make check_submodule config.mk` *(fails: Cannot find tool clang)*

------
https://chatgpt.com/codex/tasks/task_e_689491a94c248321bd92817a8a5f70e5