### PR TITLE
docs: clarify util location and build deps

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,10 +1,20 @@
 * xdp-tools - Library and utilities for use with XDP
 
-This repository contains the =libxdp= library for working with the eXpress Data Path (XDP) facility of the Linux kernel and the =xdp-trafficgen= utility for generating traffic.
+This repository contains the =libxdp= library for working with the eXpress Data Path (XDP) facility of the Linux kernel and the =xdp-trafficgen= utility for generating traffic. The traffic generator keeps its helper sources in =xdp-trafficgen/util/=.
 
-- [[lib/libxdp/][libxdp]] - XDP helper library. Build it with =./configure && make libxdp=.
-- [[xdp-trafficgen/][xdp-trafficgen]] - XDP-based packet generator. Build it with =./configure && make xdp-trafficgen=.
+** Repository layout
+- [[lib/libxdp/][libxdp]] - XDP helper library.
+- [[xdp-trafficgen/][xdp-trafficgen]] - XDP-based packet generator and supporting utilities under =xdp-trafficgen/util/=.
 
-To build both components, run =./configure= followed by =make=. Ensure a recent =libbpf= is available or fetch the bundled submodule with:
+** Building
+The project requires a modern LLVM/clang toolchain, =libelf=, =pkg-config= and =zlib=. If =libbpf= is not installed, fetch the bundled submodule with:
 
   git submodule update --init --recursive
+
+Run the usual autotools build from the repository root:
+
+  ./configure
+  make              # build everything
+  make libxdp       # build only the library
+  make xdp-trafficgen  # build only the traffic generator
+

--- a/xdp-trafficgen/README.org
+++ b/xdp-trafficgen/README.org
@@ -19,7 +19,14 @@ XDP-trafficgen supports generating UDP traffic with fixed or dynamic destination
 ports, and also has basic support for generating dummy TCP traffic on a single
 flow.
 
-** Running xdp-traffigen
+** Building and dependencies
+The source tree keeps helper code in the =util/= subdirectory. Building requires a recent LLVM/clang toolchain, =pkg-config=, =libelf= and =zlib=. From the repository root run:
+
+  git submodule update --init --recursive
+  ./configure
+  make xdp-trafficgen
+
+** Running xdp-trafficgen
 The syntax for running xdp-trafficgen is:
 
 #+begin_src sh


### PR DESCRIPTION
## Summary
- document that xdp-trafficgen's helper sources live in xdp-trafficgen/util
- spell out build dependencies and steps for libxdp and xdp-trafficgen

## Testing
- `./configure` *(fails: Cannot find tool clang)*
- `apt-get update` *(fails: repository is not signed)*
- `make test` *(fails: config.mk is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68949417885c8321aae2593a66c9eb14